### PR TITLE
Update revision date on double-spend-notifications.md

### DIFF
--- a/updates/double-spend-notifications.md
+++ b/updates/double-spend-notifications.md
@@ -207,6 +207,5 @@ The policy limits as configured by the node are used, since the conflicting tran
 
 ## Document Information
 Version 
-* 2020-05-07 – Simon Liu – initial version.
-
+* 13/05/2021 – Simon Liu – amended version.
 


### PR DESCRIPTION
The revision date on double-spend-notifications.md needs updating to reflect the date on other published documents.